### PR TITLE
[#14595]:+ Fix for default billing address if none is present when placing an order

### DIFF
--- a/app/code/Magento/Checkout/Model/PaymentInformationManagement.php
+++ b/app/code/Magento/Checkout/Model/PaymentInformationManagement.php
@@ -110,6 +110,11 @@ class PaymentInformationManagement implements \Magento\Checkout\Api\PaymentInfor
             /** @var \Magento\Quote\Model\Quote $quote */
             $quote = $quoteRepository->getActive($cartId);
             $quote->removeAddress($quote->getBillingAddress()->getId());
+            /** @var \Magento\Customer\Api\Data\CustomerInterface $customer */
+            $customer = $quote->getCustomer();
+            if (is_null($customer->getDefaultBilling())) {
+                $customer->setDefaultBilling($billingAddress->getId());
+            }
             $quote->setBillingAddress($billingAddress);
             $quote->setDataChanges(true);
             $shippingAddress = $quote->getShippingAddress();


### PR DESCRIPTION
### Description
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
Changed method savePaymentInformation where relevant payment data is being saved. The addition in this code is that an default billing address will be saved in the customer if none are present.

### Fixed Issues (if relevant)
1. magento/magento2#14595: A default billing address is not added to user

### Manual testing scenarios
1. Create new user account (with any addresses saved) or log into an existing user account without any default addresses
2. Add a product to basket & checkout
3. Select a shipping address and a shipping method and go to the next step.
4. In the payment step fill in a new address or update an existing one
5. On checkout page press submit
6. Check if default billing address is saved

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
